### PR TITLE
Implement Up-values

### DIFF
--- a/scheme-engine/src/compiler.rs
+++ b/scheme-engine/src/compiler.rs
@@ -102,7 +102,7 @@ impl Compiler {
             // Rather, variables are declared as global in the paired environment.
             local_count: 0,
             // Top-level procedure doesn't close over anything, because
-            // there is no outer scopes.
+            // there are no outer scopes.
             up_value_count: 0,
             // By storing the procedure in the environment
             // we've created a circular reference.

--- a/scheme-engine/src/compiler.rs
+++ b/scheme-engine/src/compiler.rs
@@ -244,6 +244,7 @@ impl Compiler {
     }
 
     fn compile_end(&mut self) -> Result<()> {
+        self.proc.emit_op(Op::Return);
         self.proc.emit_op(Op::End);
         Ok(())
     }

--- a/scheme-engine/src/compiler.rs
+++ b/scheme-engine/src/compiler.rs
@@ -851,13 +851,13 @@ struct UpValueInfo {
 /// call stack when a closure is instantiated, because multiple
 /// closures can be nested and returned.
 ///
-/// In this example z is local, y is an up-value in the parent's locals (scope `Parent`),
-/// and x is an up-value in the parent's up-values (scope `Outer`).
+/// In this example z is local, y is an up-value in the parent's locals (origin `Parent`),
+/// and x is an up-value in the parent's up-values (origin `Outer`).
 ///
 /// ```scheme
-/// (lambda (x)
-///   (lambda (y)
-///     (lambda (z)
+/// (lambda (x)      ;; outer
+///   (lambda (y)    ;; parent
+///     (lambda (z)  ;; local
 ///       (+ x y z)
 ///   )))
 /// ```

--- a/scheme-engine/src/compiler.rs
+++ b/scheme-engine/src/compiler.rs
@@ -104,6 +104,9 @@ impl Compiler {
             arity: 0,
             variadic: false,
             constants: proc.constants.into_boxed_slice(),
+            // Top-level procedure doesn't have local variables.
+            // Rather, variables are declared as global in the paired environment.
+            local_count: 0,
             // Top-level procedure doesn't close over anything, because
             // there is no outer scopes.
             up_value_count: 0,
@@ -978,6 +981,7 @@ impl ProcState {
             code,
             arity,
             variadic,
+            locals,
             constants,
             up_values,
             ..
@@ -988,6 +992,7 @@ impl ProcState {
             arity,
             variadic,
             constants: constants.into_boxed_slice(),
+            local_count: locals.len(),
             up_value_count: up_values.len(),
             env: env.downgrade(),
         }

--- a/scheme-engine/src/env.rs
+++ b/scheme-engine/src/env.rs
@@ -13,13 +13,21 @@ declare_id!(
     /// Local variable location identifier.
     ///
     /// This is the offset within the local scope, relative to the
-    /// call frame's starting position in the dynamic operand stack.
+    /// call frame's starting position in the dynamic evaluation stack.
     ///
     /// Importantly not the static lexical scoping stack.
     ///
     /// Thus the absolute position of the local cannot be known, because its
     /// location is determined during runtime.
     pub struct LocalId(u8)
+);
+
+declare_id!(
+    /// Up-value variable location identifier.
+    ///
+    /// This is the index of the up-value in the heap buffer
+    /// of the closure.
+    pub struct UpValueId(u8)
 );
 
 pub struct Env {

--- a/scheme-engine/src/expr.rs
+++ b/scheme-engine/src/expr.rs
@@ -1,0 +1,297 @@
+use std::cell::RefCell;
+use std::fmt;
+use std::fmt::Formatter;
+use std::rc::Rc;
+
+use smol_str::SmolStr;
+
+use crate::env::{Env, LocalId};
+use crate::error::Result;
+use crate::handle::{Handle, RcWeak};
+use crate::opcode::Op;
+
+#[derive(Debug, Clone)]
+pub enum Expr {
+    /// Nil, null or none.
+    ///
+    /// While Lisp may have gotten an official `nil` value, Scheme settled
+    /// on using an empty quoted s-expression. We implicitly detect this case
+    /// and convert it to this special [`Nil`] value.
+    ///
+    /// ```scheme
+    /// '()
+    /// ```
+    Nil,
+    /// Returned by special forms or procedures that only have side-effects,
+    /// but don't evaluate to values.
+    ///
+    /// Examples are `define`, `display` and `newline`.
+    ///
+    /// Also the value of a variable that was declared, but never defined.
+    Void,
+    Bool(bool),
+    Number(f64),
+    String(String),
+    Ident(SmolStr),
+    Keyword(Keyword),
+    Quote(Box<Expr>),
+    // TODO: List must be a linked list
+    List(Vec<Expr>),
+    // TODO: Handle of tuples, or tuple of handles?
+    Pair(Handle<(Expr, Expr)>),
+    Vector(Vec<Expr>),
+    Sequence(Vec<Expr>),
+    Procedure(Rc<Proc>),
+    Closure(Handle<Closure>),
+    NativeFunc(NativeFunc),
+}
+
+impl Expr {
+    pub fn is_boolean(&self) -> bool {
+        matches!(self, Expr::Bool(_))
+    }
+
+    pub fn as_number(&self) -> Option<f64> {
+        match self {
+            Expr::Number(number) => Some(*number),
+            _ => None,
+        }
+    }
+
+    pub fn is_number(&self) -> bool {
+        matches!(self, Expr::Number(_))
+    }
+
+    pub fn as_slice(&self) -> Option<&[Expr]> {
+        match self {
+            Expr::List(list) => Some(list.as_slice()),
+            Expr::Sequence(sequence) => Some(sequence.as_slice()),
+            _ => None,
+        }
+    }
+
+    pub fn as_ident(&self) -> Option<&str> {
+        match self {
+            Expr::Ident(name) => Some(name.as_str()),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn repr(&self) -> ExprRepr {
+        ExprRepr { expr: self }
+    }
+}
+
+impl Default for Expr {
+    fn default() -> Self {
+        Expr::Nil
+    }
+}
+
+impl PartialEq<Expr> for Expr {
+    fn eq(&self, other: &Expr) -> bool {
+        use Expr::*;
+
+        match (self, other) {
+            (Nil, Nil) => true,
+            (Bool(a), Bool(b)) => a == b,
+            (Number(a), Number(b)) => a == b,
+            (String(a), String(b)) => a == b,
+            (Ident(a), Ident(b)) => a == b,
+            (Keyword(a), Keyword(b)) => a == b,
+            (Procedure(a), Procedure(b)) => Rc::ptr_eq(a, b),
+            (Closure(a), Closure(b)) => a.ptr_eq(b),
+            _ => false,
+        }
+    }
+}
+
+pub struct ExprRepr<'a> {
+    expr: &'a Expr,
+}
+
+impl<'a> fmt::Display for ExprRepr<'a> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self.expr {
+            Expr::Nil => write!(f, "'()"),
+            Expr::Bool(boolean) => {
+                if *boolean {
+                    write!(f, "#t")
+                } else {
+                    write!(f, "#f")
+                }
+            }
+            Expr::Number(number) => write!(f, "{number}"),
+            Expr::String(string) => write!(f, "{string}"),
+            Expr::Ident(name) => write!(f, "{name}"),
+            Expr::Keyword(keyword) => match keyword {
+                Keyword::Dot => write!(f, "."),
+            },
+            Expr::List(list) => {
+                write!(f, "(")?;
+                for expr in list {
+                    let repr = ExprRepr { expr };
+                    write!(f, "{repr}")?;
+                }
+                write!(f, ")")?;
+                Ok(())
+            }
+            Expr::Sequence(expressions) => {
+                write!(f, "(")?;
+                for expr in expressions {
+                    let repr = ExprRepr { expr };
+                    write!(f, "{repr}")?;
+                }
+                write!(f, ")")?;
+                Ok(())
+            }
+            Expr::Procedure(procedure) => {
+                write!(f, "<procedure {:?}>", Rc::as_ptr(procedure))
+            }
+            Expr::Closure(closure) => {
+                write!(
+                    f,
+                    "<procedure {:?}>",
+                    Rc::as_ptr(&closure.borrow().procedure_rc())
+                )
+            }
+            Expr::NativeFunc(func) => {
+                //  TODO!("keep Rust function name")
+                write!(f, "<native-function>")
+            }
+            _ => todo!("expression type repr not implemented yet"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Keyword {
+    Dot,
+}
+
+pub type NativeFunc = fn(env: &mut Env, args: &[Expr]) -> Result<Expr>;
+
+/// Procedure prototype object.
+///
+/// This should be treated as immutable, stored as a constant in the environment.
+/// It's not identified by a name.
+#[derive(Debug)]
+pub struct Proc {
+    pub(crate) code: Box<[Op]>,
+
+    /// The number of arguments this function accepts.
+    pub(crate) sig: Signature,
+
+    pub(crate) constants: Box<[Expr]>,
+
+    /// The number of local variables per call frame that this procedure needs.
+    pub(crate) local_count: usize,
+
+    /// The number of up-values that a closure of this procedure will close
+    /// over when instantiated.
+    pub(crate) up_value_count: usize,
+
+    /// The environment where the procedure was defined.
+    ///
+    /// Because the procedure is referenced by a closure, and both can
+    /// be stored in variables within the environment, a circular reference
+    /// is created that would prevent the environment from being dropped.
+    pub(crate) env: RcWeak<RefCell<Env>>,
+}
+
+/// Procedure signature.
+///
+/// Describes how many arguments a procedure takes when called.
+#[derive(Debug, Clone)]
+pub struct Signature {
+    /// The fixed number of arguments this procedure accepts.
+    pub arity: u8,
+    /// Indicates that the procedure can that a variable number of arguments
+    /// after its fixed arguments.
+    pub variadic: bool,
+}
+
+impl Signature {
+    pub(crate) const fn new(arity: u8, variadic: bool) -> Self {
+        Self { arity, variadic }
+    }
+
+    pub(crate) const fn empty() -> Self {
+        Self::new(0, false)
+    }
+}
+
+impl Proc {
+    /// Bytecode instructions for this procedure.
+    #[inline]
+    pub fn bytecode(&self) -> &[Op] {
+        &*self.code
+    }
+}
+
+/// A callable instance of a function.
+#[derive(Debug)]
+pub struct Closure {
+    /// Shared handle to the function definition.
+    ///
+    /// Procedures are considered immutable after they're compiled,
+    /// so we use [`Rc`] directly without the interior mutability
+    /// offered by [`Handle`].
+    pub(crate) proc: Rc<Proc>,
+
+    // TODO: Change to Box<[UpValue]>
+    pub(crate) up_values: Vec<Handle<UpValue>>,
+}
+
+impl Closure {
+    pub fn new(proc: Rc<Proc>) -> Self {
+        Self {
+            proc,
+            up_values: Vec::new(),
+        }
+    }
+
+    pub fn with_up_values(proc: Rc<Proc>, up_values: Vec<Handle<UpValue>>) -> Self {
+        Self { proc, up_values }
+    }
+
+    /// The procedure definition that this closure instances.
+    #[inline]
+    pub fn procedure(&self) -> &Proc {
+        &*self.proc
+    }
+
+    /// The procedure definition that this closure instances.
+    #[inline]
+    pub fn procedure_rc(&self) -> Rc<Proc> {
+        self.proc.clone()
+    }
+}
+
+/// An Up-value is a variable that is referenced within a scope, but is not
+/// local to that scope.
+#[derive(Debug, Clone)]
+pub enum UpValue {
+    /// A local variable is an **open** up-value when it is still within scope
+    /// and on the operand stack.
+    ///
+    /// In this case the up-value holds an absolute *stack offset* pointing to the
+    /// local variable.
+    Open(usize),
+
+    /// A local variable is a **closed** up-value when the closure escapes its
+    /// parent scope. The lifetime of those locals extend beyond their scope,
+    /// so must be replaced with heap allocated values.
+    ///
+    /// In this case the up-value holds a *handle* to a heap value.
+    Closed(Expr),
+}
+
+impl UpValue {
+    #[inline]
+    pub(crate) fn close(&mut self, value: Expr) {
+        // TODO: Must we stop closing a closed up-value?
+        *self = UpValue::Closed(value);
+    }
+}

--- a/scheme-engine/src/opcode.rs
+++ b/scheme-engine/src/opcode.rs
@@ -1,8 +1,9 @@
-use crate::env::{ConstantId, LocalId, UpValueId};
+use crate::env::{ConstantId, LocalId, ProcId, UpValueId};
 use crate::symbol::SymbolId;
 
 #[derive(Debug, Clone)]
 pub enum Op {
+    Bail,
     /// Push a new `nil` value onto the operand stack.
     PushNil,
     /// Push a new `#!void` value onto the operand stack.
@@ -38,11 +39,17 @@ pub enum Op {
     /// Does not implicitly pop the value off the stack.
     StoreLocalVar(LocalId),
 
+    /// Capture a variable as an up-value for the coming closure creation. See [`Op::CreateClosure`]
+    CaptureValue(UpValueOrigin),
+
     /// Instantiate a new closure object.
     ///
     /// The constant ID argument is the location of the procedure definition
     /// that this closure instantiates.
-    CreateClosure(ConstantId),
+    ///
+    /// This instruction is preceded by zero or more  [`Op::CaptureValue`] operations
+    /// that setup the stack with up-values.
+    CreateClosure(ProcId),
 
     /// Call a closure instance instance.
     CallClosure {
@@ -60,6 +67,53 @@ pub enum Op {
 
     /// End of bytecode sentinel.
     End,
+}
+
+/// Indicates how far from the local scope the up-value originated.
+///
+/// An open up-value pointing to the immediate parent scope has its
+/// value in that parent's local variables.
+///
+/// An open up-value with a value from beyond that, has to point to
+/// the parent scope's up-value list.
+///
+/// During runtime, outer scopes are not guaranteed to be on the
+/// call stack when a closure is instantiated, because multiple
+/// closures can be nested and returned.
+///
+/// In this example z is local, y is an up-value pointing to a parent's local (origin `Parent`),
+/// and x is an up-value pointing to a parent's up-value (origin `Outer`) which in turn
+/// points to the grand-parent's local.
+///
+/// ```scheme
+/// (lambda (x)      ;; outer
+///   (lambda (y)    ;; parent
+///     (lambda (z)  ;; local
+///       (+ x y z)
+///   )))
+/// ```
+///
+/// Up-values from outer scopes are copied down into inner scopes,
+/// their handles shared so "closing" will reflect in all, effectively
+/// *flattening* the closures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpValueOrigin {
+    /// UpValue is located in parent's local variables.
+    Parent(LocalId),
+    /// UpValue is located in parent's up-value list.
+    Outer(UpValueId),
+}
+
+impl UpValueOrigin {
+    #[inline]
+    fn is_parent(&self) -> bool {
+        matches!(self, UpValueOrigin::Parent(_))
+    }
+
+    #[inline]
+    fn is_outer(&self) -> bool {
+        matches!(self, UpValueOrigin::Outer(_))
+    }
 }
 
 #[cfg(test)]

--- a/scheme-engine/src/opcode.rs
+++ b/scheme-engine/src/opcode.rs
@@ -1,4 +1,4 @@
-use crate::env::{ConstantId, LocalId};
+use crate::env::{ConstantId, LocalId, UpValueId};
 use crate::symbol::SymbolId;
 
 #[derive(Debug, Clone)]
@@ -26,6 +26,9 @@ pub enum Op {
     ///
     /// Does not implicitly pop the value off the stack.
     StoreEnvVar(SymbolId),
+
+    LoadUpValue(UpValueId),
+    StoreUpValue(UpValueId),
 
     LoadLocalVar(LocalId),
 

--- a/scheme-engine/src/vm.rs
+++ b/scheme-engine/src/vm.rs
@@ -287,6 +287,10 @@ fn run_instructions(vm: &mut Vm, frame: &mut CallFrame) -> Result<ProcAction> {
                             match origin {
                                 // Create a new up-value pointing to a local variable
                                 // in the current scope.
+                                //
+                                // Be mindful of terminology here.
+                                // The current running closure is the *parent* of the child closure
+                                // that is being spawned right now.
                                 UpValueOrigin::Parent(local_id) => {
                                     let up_value = Handle::new(UpValue::Open(
                                         frame.stack_offset + local_id.as_usize(),

--- a/scheme-engine/src/vm.rs
+++ b/scheme-engine/src/vm.rs
@@ -226,7 +226,15 @@ fn run_instructions(vm: &mut Vm, frame: &mut CallFrame) -> Result<ProcAction> {
                 }
             }
             Op::StoreUpValue(up_value_id) => {
-                todo!()
+                let value = vm.operand.last().cloned().unwrap_or(Expr::Void);
+                match &mut *closure.up_values[up_value_id.as_usize()].borrow_mut() {
+                    UpValue::Open(stack_pos) => {
+                        vm.operand[*stack_pos] = value;
+                    }
+                    UpValue::Closed(up_value) => {
+                        *up_value = value;
+                    }
+                }
             }
             Op::LoadLocalVar(local_id) => {
                 let value = vm

--- a/scheme-engine/src/vm.rs
+++ b/scheme-engine/src/vm.rs
@@ -168,6 +168,12 @@ fn run_instructions(vm: &mut Vm, frame: &mut CallFrame) -> Result<ProcAction> {
                 env.set_var(symbol, value)?;
                 // don't pop
             }
+            Op::LoadUpValue(up_value_id) => {
+                todo!()
+            }
+            Op::StoreUpValue(up_value_id) => {
+                todo!()
+            }
             Op::LoadLocalVar(local_id) => {
                 let value = vm
                     .operand

--- a/scheme-engine/src/vm.rs
+++ b/scheme-engine/src/vm.rs
@@ -154,8 +154,6 @@ fn run_instructions(vm: &mut Vm, frame: &mut CallFrame) -> Result<ProcAction> {
     // Pull relevant state into flat local variables to reduce the
     // overhead of jumping pointers and bookkeeping of borrowing objects.
     let mut closure_rc = frame.closure.clone();
-    // let closure_ref = closure_rc.borrow_mut();
-    // let proc_rc = closure_ref.procedure().clone();
     let proc_rc = closure_rc.borrow().procedure_rc().clone();
     let proc = &*proc_rc;
     let closure = &mut *closure_rc.borrow_mut();

--- a/scheme-engine/tests/language/lambda.scm
+++ b/scheme-engine/tests/language/lambda.scm
@@ -20,3 +20,11 @@
     (define inner (lambda (c) (+ a b c)))
     (inner 3)))
 (assert (= (add-outer 1 2) 6))
+
+(define add-nested
+  (lambda (x)
+    (lambda (y)
+      (lambda (z)
+        (+ x y z)
+        ))))
+(assert (= (add-nested 1 2 3) 6))

--- a/scheme-engine/tests/language/lambda.scm
+++ b/scheme-engine/tests/language/lambda.scm
@@ -12,3 +12,11 @@
 
 ;; Test nested lambda calls
 (define add-add-self (lambda (a b) (+ (add-self a) (add-self b)))) (assert (= (add-add-self 7 11) 36))
+
+
+;; Test upvalue capture
+(define add-outer
+  (lambda (a b)
+    (define inner (lambda (c) (+ a b c)))
+    (inner 3)))
+(assert (= (add-outer 1 2) 6))

--- a/scheme-engine/tests/language/lambda.scm
+++ b/scheme-engine/tests/language/lambda.scm
@@ -27,4 +27,6 @@
       (lambda (z)
         (+ x y z)
         ))))
-(assert (= (add-nested 1 2 3) 6))
+(assert (=
+          (((add-nested 13) 17) 19)
+          49))

--- a/scheme-engine/tests/test_lambda.rs
+++ b/scheme-engine/tests/test_lambda.rs
@@ -5,8 +5,7 @@ use scheme_engine::Expr;
 /// outer scope.
 #[test]
 fn test_lambda_call() {
-    let source =
-        r"(define add-self (lambda (x) (+ x x))) (add-self 7) (assert (= (add-self 7) 14))";
+    let source = r"(define add-self (lambda (x) (+ x x))) (add-self 7)";
 
     let env = scheme_engine::new_env().expect("create core environment");
     let expr = scheme_engine::parse(source, true).expect("parse");


### PR DESCRIPTION
This implements up-values, and closures capturing variables from outer scopes.

```scheme
(define add-all (lambda (x) (lambda (y) (lambda (z) (+ x y z)))))
(((add-all 1) 2) 3)
;;> 6
```